### PR TITLE
Initial release of goenv module.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,5 @@
+fixtures:
+  repositories:
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+  symlinks:
+    goenv: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.*.sw?
+pkg
+spec/fixtures

--- a/.nodeset.yml
+++ b/.nodeset.yml
@@ -1,0 +1,11 @@
+---
+default_set: 'ubuntu-server-12042-x64'
+sets:
+  'ubuntu-server-10044-x64':
+    nodes:
+      "main.foo.vm":
+        prefab: 'ubuntu-server-10044-x64'
+  'ubuntu-server-12042-x64':
+    nodes:
+      "main.foo.vm":
+        prefab: 'ubuntu-server-12042-x64'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+---
+# Verify this with: http://lint.travis-ci.org/
+language: ruby
+# Delete dependency locks for matrix builds.
+before_install: rm Gemfile.lock || true
+script: bundle exec rake test
+rvm:
+  - 1.8.7
+  - 1.9.3
+env:
+  matrix:
+  - PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 3.1.0"
+  - PUPPET_VERSION="~> 3.2.0"
+  - PUPPET_VERSION="~> 3.4.0"
+# Only notify for failed builds.
+notifications:
+  email:
+    on_success: never

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,2 @@
+2014-09-09 Release 0.0.1
+- Initial release based on rbenv module

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+
+# Versions can be overridden with environment variables for matrix testing.
+# Travis will remove Gemfile.lock before installing deps.
+
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.2.0'
+
+gem 'rake'
+gem 'puppet-lint'
+gem 'rspec-puppet'
+gem 'rspec-system-puppet'
+gem 'puppetlabs_spec_helper'
+gem 'puppet-syntax'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,102 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    excon (0.39.5)
+    facter (1.7.6)
+    fog (1.23.0)
+      fog-brightbox
+      fog-core (~> 1.23)
+      fog-json
+      fog-softlayer
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-brightbox (0.3.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto
+    fog-core (1.24.0)
+      builder
+      excon (~> 0.38)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-json (1.0.0)
+      multi_json (~> 1.0)
+    fog-softlayer (0.3.15)
+      fog-core
+      fog-json
+    formatador (0.2.5)
+    hiera (1.3.4)
+      json_pure
+    inflecto (0.0.2)
+    ipaddress (0.8.0)
+    json_pure (1.8.1)
+    kwalify (0.7.2)
+    metaclass (0.0.4)
+    mime-types (1.25.1)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.10.1)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.1)
+    nokogiri (1.5.11)
+    puppet (3.2.4)
+      facter (~> 1.6)
+      hiera (~> 1.0)
+      rgen (~> 0.6.5)
+    puppet-lint (1.0.1)
+    puppet-syntax (1.3.0)
+      rake
+    puppetlabs_spec_helper (0.8.1)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec
+      rspec-puppet
+    rake (10.3.2)
+    rbvmomi (1.8.1)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    rgen (0.6.6)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.2)
+    rspec-puppet (1.0.1)
+      rspec
+    rspec-system (2.8.0)
+      fog (~> 1.18)
+      kwalify (~> 0.7.2)
+      mime-types (~> 1.16)
+      net-scp (~> 1.1)
+      net-ssh (~> 2.7)
+      nokogiri (~> 1.5.10)
+      rbvmomi (~> 1.6)
+      rspec (~> 2.14)
+      systemu (~> 2.5)
+    rspec-system-puppet (2.2.1)
+      rspec-system (~> 2.0)
+    systemu (2.6.4)
+    trollop (2.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  puppet (~> 3.2.0)
+  puppet-lint
+  puppet-syntax
+  puppetlabs_spec_helper
+  rake
+  rspec-puppet
+  rspec-system-puppet

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright (c) 2014 Government Digital Service
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Modulefile
+++ b/Modulefile
@@ -1,0 +1,9 @@
+name          'gdsoperations-goenv'
+version       '0.0.1'
+source        'https://github.com/gds-operations/puppet-goenv'
+author        'Government Digital Service'
+license       'MIT'
+summary       'System wide goenv'
+project_page  'https://github.com/gds-operations/puppet-goenv'
+
+dependency 'puppetlabs/stdlib', '>= 3.0.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,28 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'rspec-system/rake_task'
+
+PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.fail_on_warnings = true
+
+# Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
+# http://puppet-lint.com/checks/class_parameter_defaults/
+PuppetLint.configuration.send('disable_class_parameter_defaults')
+# http://puppet-lint.com/checks/class_inherits_from_params_class/
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths = exclude_paths
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -1,0 +1,24 @@
+# == Class: goenv::global
+#
+# Set a Go version as the global. This is intended to be called by the
+# parent `Goenv` class. It should not be called directly.
+#
+# === Parameters:
+#
+class goenv::global {
+  include goenv::params
+
+  $version = $::goenv::global_version
+
+  if $version {
+    file { $goenv::params::global_version:
+      ensure  => present,
+      content => "${version}\n",
+      require => Goenv::Version[$version],
+    }
+  } else {
+    file { $goenv::params::global_version:
+      ensure => absent,
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,30 @@
+# == Class: goenv
+#
+# Install goenv from a system package and create an `/etc/profile.d` to do
+# the following for all new shell sessions:
+#
+# - Set `GOENT_ROOT` to a common system path.
+# - Run `goenv init`.
+#
+# === Parameters:
+#
+# [*global_version*]
+#   Version to use. A matching `Goenv::Version[]` resource must exist if
+#   specified.
+#   Default: undef
+#
+class goenv(
+  $global_version = undef
+) {
+  include goenv::params
+
+  package { 'goenv':
+    ensure => latest,
+  } ->
+  file { '/etc/profile.d/goenv.sh':
+    ensure  => present,
+    mode    => '0755',
+    content => template('goenv/etc/profile.d/goenv.sh.erb'),
+  } ->
+  class { 'goenv::global': }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,16 @@
+# == Class: goenv::params
+#
+# Common variables referred to by other sub-classes.
+#
+class goenv::params {
+  case $::osfamily {
+    'Debian': {
+      $goenv_root     = '/usr/lib/goenv'
+      $goenv_binary   = '/usr/bin/goenv'
+      $global_version = "${goenv_root}/version"
+    }
+    default: {
+      fail("${::operatingsystem} not supported")
+    }
+  }
+}

--- a/manifests/rehash.pp
+++ b/manifests/rehash.pp
@@ -1,0 +1,28 @@
+# == Define: goenv::rehash
+#
+# Run `goenv rehash` for a specific version of Go. Typically refreshed by
+# `Goenv::Version[]` after installation.
+#
+# The title of the resource is used as the version.
+#
+# NB: Exec[] resources do not assume that goenv has been initialised from
+# `profile.d` because Puppet may be running from a non-login and
+# non-interactive shell (e.g. cron). They explicitly pass `GOENV_ROOT` and
+# GOENV_VERSION for this reason.
+#
+# TODO: Does this need to be version specific?
+#
+define goenv::rehash() {
+  include goenv::params
+
+  $version = $title
+
+  exec { "goenv rehash for ${version}":
+    command     => "${goenv::params::goenv_binary} rehash",
+    environment => [
+      "GOENV_ROOT=${goenv::params::goenv_root}",
+      "GOENV_VERSION=${version}",
+    ],
+    refreshonly => true,
+  }
+}

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -1,0 +1,24 @@
+# == Class: goenv::version
+#
+# Install a version of Go under goenv from a system package.
+#
+# The title of the resource is used as the version.
+#
+# === Examples
+#
+# goenv { ['1.2.2', '1.3.1']: }
+#
+define goenv::version () {
+  include goenv::params
+
+  $version = $title
+  $package_name = "goenv-go-${version}"
+
+  package { $package_name:
+    ensure  => latest,
+    notify  => Goenv::Rehash[$version],
+    require => Class['goenv'],
+  }
+
+  goenv::rehash { $version: }
+}

--- a/spec/classes/goenv__global_spec.rb
+++ b/spec/classes/goenv__global_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+# Focus on goenv::global proxy of goenv
+describe 'goenv' do
+  let(:facts) {{
+    :osfamily => 'Debian',
+  }}
+  let(:file_path) { '/usr/lib/goenv/version' }
+
+  context 'when version is default(undef), remove the file' do
+    it {
+      should contain_file(file_path).with_ensure('absent')
+    }
+  end
+
+  context 'when version is 1.2.3' do
+    let(:params) {{
+      :global_version => '1.2.3',
+    }}
+
+    it {
+      should contain_file(file_path).with(
+        :content => "1.2.3\n",
+        :require => 'Goenv::Version[1.2.3]'
+      )
+    }
+  end
+end

--- a/spec/classes/goenv_spec.rb
+++ b/spec/classes/goenv_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'goenv' do
+  let(:facts) {{
+    :osfamily => 'Debian',
+  }}
+
+  context 'standard resources' do
+    it { should contain_package('goenv') }
+
+    it {
+      should contain_file('/etc/profile.d/goenv.sh').with(
+        :mode    => '0755',
+        :content => /GOENV_ROOT="\/usr\/lib\/goenv"/
+      )
+    }
+  end
+
+  context 'global_version uses default from goenv::global' do
+    it { should contain_class('goenv::global') }
+  end
+
+  context 'global_version is 1.2.3' do
+    let(:params) {{
+      :global_version => '1.2.3',
+    }}
+
+    it { should contain_class('goenv::global') }
+  end
+end

--- a/spec/defines/rbenv__rehash_spec.rb
+++ b/spec/defines/rbenv__rehash_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'goenv::rehash' do
+  let(:facts) {{
+    :osfamily => 'Debian',
+  }}
+
+  context 'Version 1.2.2' do
+    let(:title) { '1.2.2' }
+
+    it {
+      should contain_exec('goenv rehash for 1.2.2').with(
+        :command     => '/usr/bin/goenv rehash',
+        :environment => [
+          'GOENV_ROOT=/usr/lib/goenv',
+          'GOENV_VERSION=1.2.2',
+        ],
+        :refreshonly => true
+      )
+    }
+  end
+end

--- a/spec/defines/rbenv__version_spec.rb
+++ b/spec/defines/rbenv__version_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'goenv::version' do
+  let(:facts) {{
+    :osfamily => 'Debian',
+    :path     => '/usr/lib/goenv/versions/1.2.2/bin:/usr/lib/goenv/shims:/usr/sbin:/usr/bin:/sbin:/bin',
+  }}
+
+  context 'Version 1.2.2' do
+    let(:title) { '1.2.2' }
+
+    context 'go version' do
+      it {
+        should contain_package('goenv-go-1.2.2').with(
+          :ensure  => "latest",
+          :notify  => "Goenv::Rehash[1.2.2]",
+          :require => 'Class[Goenv]'
+        )
+      }
+    end
+
+    context 'rehash' do
+      it { should contain_goenv__rehash('1.2.2') }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -1,0 +1,16 @@
+require 'rspec-system/spec_helper'
+require 'rspec-system-puppet/helpers'
+
+include RSpecSystemPuppet::Helpers
+
+RSpec.configure do |c|
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+  c.tty = true
+  c.include RSpecSystemPuppet::Helpers
+
+  c.before :suite do
+    puppet_install
+    puppet_module_install(:source => proj_root, :module_name => 'goenv')
+    shell('puppet module install puppetlabs-stdlib')
+  end
+end

--- a/spec/system/basic_spec.rb
+++ b/spec/system/basic_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper_system'
+
+describe 'basic tests' do
+  it 'class should work without errors' do
+    pp = <<-EOS
+      class { 'goenv': }
+    EOS
+
+    puppet_apply(pp) do |r|
+      r.exit_code.should == 2
+    end
+  end
+end

--- a/templates/etc/profile.d/goenv.sh.erb
+++ b/templates/etc/profile.d/goenv.sh.erb
@@ -1,0 +1,2 @@
+export GOENV_ROOT="<%= scope.lookupvar('goenv::params::goenv_root') -%>"
+[ -d "$GOENV_ROOT" ] && eval "$(goenv init -)"

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,0 +1,12 @@
+# The baseline for module testing used by Puppet Labs is that each manifest
+# should have a corresponding test manifest that declares that class or defined
+# type.
+#
+# Tests are then run by using puppet apply --noop (to check for compilation
+# errors and view a log of events) or by fully applying the test in a virtual
+# environment (to compare the resulting system state to the desired state).
+#
+# Learn more about module testing here:
+# http://docs.puppetlabs.com/guides/tests_smoke.html
+#
+include goenv


### PR DESCRIPTION
This is based on the existing rbenv module with some bits removed:
- Bundler bits - there's no equivelent for Go
- Alias support - not needed for Go

**Note:** This depends on some debian packages; see alphagov/packager#42 and alphagov/packager#43
