### PR TITLE
Disable goenv install and uninstall commands.

### DIFF
--- a/files/libexec/goenv-install-stub
+++ b/files/libexec/goenv-install-stub
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cat <<EOT
+goenv install/uninstall are disabled on this system because
+individual Go versions are managed as system packages.
+EOT
+exit 1

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,9 +18,7 @@ class goenv(
 ) {
   include goenv::params
 
-  package { 'goenv':
-    ensure => latest,
-  } ->
+  class { 'goenv::package': } ->
   file { '/etc/profile.d/goenv.sh':
     ensure  => present,
     mode    => '0755',

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,0 +1,32 @@
+# == Class: goenv::package
+#
+# Install the goenv package. Additionally disables the goenv install and
+# ununstall commands, to prevent conflicts with the package-managed versions.
+#
+class goenv::package {
+  package { 'goenv':
+    ensure => latest,
+  }
+
+  $libexec_dir = '/usr/lib/goenv/libexec'
+
+  exec { 'dpkg-divert_of_goenv-install':
+    command => "dpkg-divert --rename ${libexec_dir}/goenv-install",
+    creates => "${libexec_dir}/goenv-install.distrib",
+    require => Package['goenv'],
+  } ->
+  file { "${libexec_dir}/goenv-install":
+    source => 'puppet:///modules/goenv/libexec/goenv-install-stub',
+    mode   => '0755',
+  }
+
+  exec { 'dpkg-divert_of_goenv-uninstall':
+    command => "dpkg-divert --rename ${libexec_dir}/goenv-uninstall",
+    creates => "${libexec_dir}/goenv-uninstall.distrib",
+    require => Package['goenv'],
+  } ->
+  file { "${libexec_dir}/goenv-uninstall":
+    source => 'puppet:///modules/goenv/libexec/goenv-install-stub',
+    mode   => '0755',
+  }
+}


### PR DESCRIPTION
These could cause problems/confusion with the package-managed Go
versons.  Better to disable them.
