### PR TITLE
Allow ensure => absent for versions.

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -8,15 +8,36 @@
 #
 # goenv { ['1.2.2', '1.3.1']: }
 #
-define goenv::version () {
+# === Parameters
+#
+# [*ensure*]
+#   present or absent. Whether to install or remove this version.
+#   Default: present
+#
+define goenv::version (
+  $ensure = present,
+) {
   include goenv::params
 
   $version = $title
 
-  exec { "install-goenv-go-${version}":
-    command     => "${goenv::params::goenv_binary} install ${version}",
-    environment => "GOENV_ROOT=${goenv::params::goenv_root}",
-    creates     => "${goenv::params::goenv_root}/versions/${version}/bin/go",
-    require     => Class['goenv'],
+  if $ensure == present {
+
+    exec { "install-goenv-go-${version}":
+      command     => "${goenv::params::goenv_binary} install ${version}",
+      environment => "GOENV_ROOT=${goenv::params::goenv_root}",
+      creates     => "${goenv::params::goenv_root}/versions/${version}/bin/go",
+      require     => Class['goenv'],
+    }
+
+  } else {
+
+    exec { "uninstall-goenv-go-${version}":
+      command     => "${goenv::params::goenv_binary} uninstall ${version}",
+      environment => "GOENV_ROOT=${goenv::params::goenv_root}",
+      onlyif      => "test -d ${goenv::params::goenv_root}/versions/${version}",
+      require     => Class['goenv'],
+    }
+
   }
 }

--- a/spec/defines/rbenv__version_spec.rb
+++ b/spec/defines/rbenv__version_spec.rb
@@ -18,4 +18,22 @@ describe 'goenv::version' do
       )
     }
   end
+
+  describe "removing a version" do
+    let(:title) { '1.2.1' }
+    let(:params) {{
+      "ensure" => "absent",
+    }}
+
+    it {
+      should contain_exec('uninstall-goenv-go-1.2.1').with(
+        :command => "/usr/bin/goenv uninstall 1.2.1",
+        :environment => "GOENV_ROOT=/usr/lib/goenv",
+        :onlyif => "test -d /usr/lib/goenv/versions/1.2.1",
+        :require => 'Class[Goenv]'
+      )
+    }
+
+    it { should_not contain_exec('install-goenv-go-1.2.1') }
+  end
 end


### PR DESCRIPTION
In order to allow removing a version from a machine, this adds the
abiliry to specify `ensure => absent` for a version.