### PR TITLE
Migrate from Modulefile to metadata.json

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,7 +1,0 @@
-name          'gdsoperations-goenv'
-version       '0.0.4'
-source        'https://github.com/gds-operations/puppet-goenv'
-author        'Government Digital Service'
-license       'MIT'
-summary       'System wide goenv'
-project_page  'https://github.com/gds-operations/puppet-goenv'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name":         "gdsoperations-goenv",
+  "version":      "0.0.4",
+  "author":       "Government Digital Service",
+  "license":      "MIT",
+  "summary":      "System wide goenv",
+  "source":       "https://github.com/gds-operations/puppet-goenv",
+  "project_page": "https://github.com/gds-operations/puppet-goenv",
+  "issues_url":   "https://github.com/gds-operations/puppet-goenv/issues",
+  "tags":         ["go", "golang"],
+  "operatingsystem_support": [
+    {
+    "operatingsystem": "Ubuntu",
+    "operatingsystemrelease": ["12.04", "14.04"]
+    }
+  ],
+  "dependencies": [
+  ]
+}


### PR DESCRIPTION
Modulefile is deprecated, metadata.json is the current
chosen solution.